### PR TITLE
Add missing `daptm:represents`

### DIFF
--- a/dapt1/validation/invalid/dapt-invld-agent-actor-id-invalid.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-actor-id-invalid.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent xml:id="actor_A" type="person">

--- a/dapt1/validation/invalid/dapt-invld-agent-actor-id-not-agent.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-actor-id-not-agent.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent xml:id="actor_A" type="person">

--- a/dapt1/validation/invalid/dapt-invld-agent-actor-id-undeclared.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-actor-id-undeclared.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent xml:id="actor_A" type="person">

--- a/dapt1/validation/invalid/dapt-invld-agent-actor-is-parent.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-actor-is-parent.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent xml:id="actor_A" type="person">

--- a/dapt1/validation/invalid/dapt-invld-agent-invalid-xmlId.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-invalid-xmlId.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent type="person" xml:id="#invalid">

--- a/dapt1/validation/invalid/dapt-invld-agent-no-name.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-no-name.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent type="person" xml:id="actor_A">

--- a/dapt1/validation/invalid/dapt-invld-agent-no-xmlId.xml
+++ b/dapt1/validation/invalid/dapt-invld-agent-no-xmlId.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <ttm:agent type="person">

--- a/dapt1/validation/invalid/dapt-invld-contentProfiles-im3t-no-dapt.xml
+++ b/dapt1/validation/invalid/dapt-invld-contentProfiles-im3t-no-dapt.xml
@@ -4,5 +4,6 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/imsc1.2/text"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
 </tt>

--- a/dapt1/validation/invalid/dapt-invld-contentProfiles-omitted.xml
+++ b/dapt1/validation/invalid/dapt-invld-contentProfiles-omitted.xml
@@ -3,5 +3,6 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
 </tt>

--- a/dapt1/validation/invalid/dapt-invld-descType-extension-value.xml
+++ b/dapt1/validation/invalid/dapt-invld-descType-extension-value.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1">
             <ttm:desc daptm:descType="invalid-extension">Description using invalid extension descType</ttm:desc>

--- a/dapt1/validation/invalid/dapt-invld-onScreen.xml
+++ b/dapt1/validation/invalid/dapt-invld-onScreen.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1" daptm:onScreen="INVALID"/>
     </body>

--- a/dapt1/validation/invalid/dapt-invld-originTimecode-bad-format.xml
+++ b/dapt1/validation/invalid/dapt-invld-originTimecode-bad-format.xml
@@ -4,7 +4,8 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     ttp:frameRate="25"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <daptm:daptOriginTimecode>10012012</daptm:daptOriginTimecode>

--- a/dapt1/validation/invalid/dapt-invld-originTimecode-frames-too-many.xml
+++ b/dapt1/validation/invalid/dapt-invld-originTimecode-frames-too-many.xml
@@ -4,7 +4,8 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     ttp:frameRate="10"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <daptm:daptOriginTimecode>10:01:20:12</daptm:daptOriginTimecode>

--- a/dapt1/validation/invalid/dapt-invld-originTimecode-no-framerate.xml
+++ b/dapt1/validation/invalid/dapt-invld-originTimecode-no-framerate.xml
@@ -3,7 +3,8 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <daptm:daptOriginTimecode>10:01:20:12</daptm:daptOriginTimecode>

--- a/dapt1/validation/invalid/dapt-invld-originTimecode-too-many.xml
+++ b/dapt1/validation/invalid/dapt-invld-originTimecode-too-many.xml
@@ -4,7 +4,8 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     ttp:frameRate="25"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <head>
         <metadata>
             <daptm:daptOriginTimecode>10:01:20:12</daptm:daptOriginTimecode>

--- a/dapt1/validation/invalid/dapt-invld-profile.xml
+++ b/dapt1/validation/invalid/dapt-invld-profile.xml
@@ -5,5 +5,6 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     ttp:profile="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
 </tt>

--- a/dapt1/validation/invalid/dapt-invld-serialization-encoding-iso8859-1.xml
+++ b/dapt1/validation/invalid/dapt-invld-serialization-encoding-iso8859-1.xml
@@ -5,7 +5,8 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     daptm:scriptType="originalTranscript" xml:lang="en"
-    daptm:scriptRepresents="audio">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    >
     <body>
         <div xml:id="d1">
             <p>Predefined entity: &lt;</p>

--- a/dapt1/validation/invalid/dapt-invld-serialization-entity-declaration-and-ref.xml
+++ b/dapt1/validation/invalid/dapt-invld-serialization-entity-declaration-and-ref.xml
@@ -8,7 +8,8 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     daptm:scriptType="originalTranscript" xml:lang="en"
-    daptm:scriptRepresents="audio">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    >
     <body>
         <div xml:id="d1">
             <p>Entity reference: &entity;</p>

--- a/dapt1/validation/invalid/dapt-invld-xmlLang-root-empty.xml
+++ b/dapt1/validation/invalid/dapt-invld-xmlLang-root-empty.xml
@@ -3,6 +3,7 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="">
     <!-- The empty xml:lang attribute cannot be expressed as invalid in an XML Schema Document 1.0 -->
 </tt>

--- a/dapt1/validation/invalid/dapt-invld-xmlLang-root-invalid.xml
+++ b/dapt1/validation/invalid/dapt-invld-xmlLang-root-invalid.xml
@@ -3,5 +3,6 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="#invalid">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="#invalid">
 </tt>

--- a/dapt1/validation/invalid/dapt-invld-xmlLang-root-missing.xml
+++ b/dapt1/validation/invalid/dapt-invld-xmlLang-root-missing.xml
@@ -3,5 +3,6 @@
     xmlns:daptm="http://www.w3.org/ns/ttml/profile/dapt#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript">
 </tt>

--- a/dapt1/validation/valid/dapt-valid-descType-extension-value.xml
+++ b/dapt1/validation/valid/dapt-valid-descType-extension-value.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1">
             <ttm:desc daptm:descType="x-extension">Description using extension descType</ttm:desc>

--- a/dapt1/validation/valid/dapt-valid-descType-no-descType.xml
+++ b/dapt1/validation/valid/dapt-valid-descType-no-descType.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1">
             <ttm:desc>No descType description</ttm:desc>

--- a/dapt1/validation/valid/dapt-valid-descType-registry-value.xml
+++ b/dapt1/validation/valid/dapt-valid-descType-registry-value.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1">
             <ttm:desc daptm:descType="scene">Scene identifier</ttm:desc>

--- a/dapt1/validation/valid/dapt-valid-onScreen.xml
+++ b/dapt1/validation/valid/dapt-valid-onScreen.xml
@@ -4,7 +4,8 @@
     xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
-    daptm:scriptRepresents="audio" daptm:scriptType="originalTranscript" xml:lang="en">
+    daptm:scriptRepresents="audio" daptm:represents="audio"
+    daptm:scriptType="originalTranscript" xml:lang="en">
     <body>
         <div xml:id="d1" daptm:onScreen="OFF"/>
         <div xml:id="d2" daptm:onScreen="OFF_ON"/>

--- a/dapt1/validation/valid/dapt-valid-originTimecode.xml
+++ b/dapt1/validation/valid/dapt-valid-originTimecode.xml
@@ -11,7 +11,7 @@
         </metadata>
     </head>
     <body>
-        <div xml:id="se1" begin="0s" end="1.8s">
+        <div xml:id="se1" begin="0s" end="1.8s" daptm:represents="audio">
             <!-- This script event was generated from a source whose begin timecode was 10:01:20:12 -->
         </div>
     </body>

--- a/dapt1/validation/valid/dapt-valid-scriptEventMapping.xml
+++ b/dapt1/validation/valid/dapt-valid-scriptEventMapping.xml
@@ -5,7 +5,7 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     daptm:scriptType="originalTranscript" xml:lang="en"
-    daptm:scriptRepresents="audio">
+    daptm:scriptRepresents="audio" daptm:represents="audio">
     <body>
         <div xml:id="d1"><!-- Script Event with no Text --></div>
         <div xml:id="d2">

--- a/dapt1/validation/valid/dapt-valid-serialization.xml
+++ b/dapt1/validation/valid/dapt-valid-serialization.xml
@@ -5,7 +5,7 @@
     xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
     ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
     daptm:scriptType="originalTranscript" xml:lang="en"
-    daptm:scriptRepresents="audio">
+    daptm:scriptRepresents="audio" daptm:represents="audio">
     <body>
         <div xml:id="d1">
             <p>Predefined entity: &lt;</p>


### PR DESCRIPTION
Avoids unintentionally invalidating valid test files, and invalidating invalid test files for the wrong reason.

Closes #41 